### PR TITLE
Toml/metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,39 @@
 # policies
+
 Policy documents for services run by New Vector
 
-You can generate a full set of html docs from the .md source using:
+## Versioning
+
+Documents are versioned using semver:
+
+- Major bump - significant change requiring subjects' specific re-acknowledgement/acceptance
+- Minor bump - notable change in text, but not something that would require subjects' specific attention
+- Patch bump - fixing a typo
+
+Versioning metadata is stored in the top of the policy doc - each doc has a metadata segment inspired by gatsby that looks something like:
+
+```
+---
+title: Document Title
+slug: Document Title
+version 1.0.0
+---
+```
+
+Identity servers and integration managers manage tracking subjects' 'accepted terms' by tracking the URL representing those terms - it is therefore *imperative* that any generated links to docs include the major version _and only the major version_ (e.g. https://example.com/document-title-1) so that only a change in the major version triggers the 're-optin' flow.
+
+### Versioning Tooling
+
+`/scripts/versions.py` will mine the github commit history for a given document and output a file representing the most recent state of that document for each numbered version. `versions.py` doesn't handle templating or markdown->html.
+
+## Building the Docs
+
+This section needs some work. You can generate a full set of html docs from the .md source using:
 
 ```
 npm run build
 ```
 
-This will create a `/build' directory with a folder structure mirroring `/docs`, with a .html file in place of every .md file.
+This will create a `/build` directory with a folder structure mirroring `/docs`, with a .html file in place of every .md file.
+
+At the moment this does not play nicely with `versions.py`, and it is questionable whether it is a good idea at all to have a build system as part of the docs repo when, in some instances at least (such as the matrix.org website) what's needed is a markdown file that gatsby will then ingest.

--- a/docs/hosted-homeserver/code_of_conduct.md
+++ b/docs/hosted-homeserver/code_of_conduct.md
@@ -1,4 +1,8 @@
-# Matrix Code of Conduct
+---
+title: Matrix Code of Conduct
+slug: Code of Conduct
+version: 1.0.0
+---
 
 This code of conduct outlines our expectations for participants within the Matrix community, as well as steps for reporting unacceptable behaviour. We are committed to providing a welcoming and inspiring community for all, and expect our code of conduct to be honoured. Anyone who violates this code of conduct may be banned from the community.
 

--- a/docs/hosted-homeserver/copyright_notice.md
+++ b/docs/hosted-homeserver/copyright_notice.md
@@ -1,4 +1,8 @@
-# {{ hhs_entity_name }} ({{ hhs_name }}.{{ hhs_server_domain }}) Copyright Notice
+--
+title: {{ hhs_entity_name }} ({{ hhs_name }}.{{ hhs_server_domain }}) Copyright Notice
+slug: Copyright Notice
+version: 1.0.0
+---
 
 Where you read *New Vector*, *New Vector Ltd.* or *we *or* us* below, it refers to New Vector Ltd., and its French subsidiary: New Vector SARL and their agents.
 

--- a/docs/hosted-homeserver/exceptional_erasure_policy.md
+++ b/docs/hosted-homeserver/exceptional_erasure_policy.md
@@ -1,6 +1,10 @@
-# {{ hhs_entity_name }} ({{ hhs_name }}.{{ hhs_server_domain }}) Policy for Exceptional Exercising of Right To Erasure on State Events
+---
+title: {{ hhs_entity_name }} ({{ hhs_name }}.{{ hhs_server_domain }}) Policy for Exceptional Exercising of Right To Erasure on State Events
+slug: Exceptional Erasure Policy
+version: 1.0.0
+---
 
-# 1. Introduction
+## 1. Introduction
 
 Where you read *New Vector*, *New Vector Ltd.* or *we *or* us* below, it refers to New Vector Ltd., and its French subsidiary: New Vector SARL and their agents. **This policy does not apply to Matrix servers run by anyone else - Matrix is an open network like the Web and this policy only applies to the server ({{ hhs_name }}.{{ hhs_server_domain }}) provided by New Vector Ltd.**
 
@@ -8,7 +12,7 @@ The legal basis for our processing Personal Data, the reasons for there being re
 
 This document serves to detail how we decide what to do in the event of the interests of an individual user appearing to be in conflict with the broader societal interests.
 
-# 2. How we decide
+## 2. How we decide
 
 As described in the [full {{ hhs_name }}.{{ hhs_server_domain }} Privacy Notice](http://{{ hhs_name }}.{{ hhs_client_domain }}/privacy_policy/en/privacy_notice.html), erasing state events is very damaging to the integrity of a Matrix conversation.
 
@@ -26,6 +30,6 @@ The Personal Data contained in a state event is usually limited to the username,
 
 Each case will be decided based on the factors listed above. In most situations we will not erase state events. In extreme situations, where not erasing state events will place people at material risk of harm, we may choose to erase state events or remove the entire conversation.
 
-# 3. Contacting Us
+## 3. Contacting Us
 
 If you would like us to consider erasing state events containing your Personal Data, please get in touch at [support@modular.im](mailto:support@modular.im).

--- a/docs/hosted-homeserver/privacy_notice.md
+++ b/docs/hosted-homeserver/privacy_notice.md
@@ -1,4 +1,8 @@
-# {{ hhs_entity_name }} ({{ hhs_name }}.{{ hhs_server_domain }}) Homeserver Privacy Notice
+---
+title: {{ hhs_entity_name }} ({{ hhs_name }}.{{ hhs_server_domain }}) Homeserver Privacy Notice
+slug: Homeserver Privacy Notice
+version: 1.0.0
+---
 
 Please read this document carefully before accessing or using this service!
 

--- a/docs/hosted-homeserver/terms_and_conditions.md
+++ b/docs/hosted-homeserver/terms_and_conditions.md
@@ -1,4 +1,8 @@
-# {{ hhs_entity_name }} ({{ hhs_name }}.{{ hhs_server_domain }}) Homeserver User Terms and Conditions
+---
+title: {{ hhs_entity_name }} ({{ hhs_name }}.{{ hhs_server_domain }}) Homeserver User Terms and Conditions
+slug: Homeserver User Terms and Conditions
+version: 1.0.0
+---
 
 These User Terms and Conditions ('User Terms') describe your rights and responsibilities when using the services enabled by the {{ hhs_name }}.{{ hhs_server_domain }} Homeserver. Please read this document carefully before accessing or using this service!
 
@@ -10,7 +14,7 @@ Most Terms of Use and Privacy Policy documents are unreadable. They are written 
 
 We decided to use plain English as much as possible, to make our terms as clear as possible. Some sections still have room for improvement - we plan to tackle these over time.
 
-### 1.2 Definition of Terms
+### 1.2 Definition of Terms
 
 You have been invited, or you have registered freely, to use a communication service which is controlled by a 'Homeserver Owner'. You are as such an 'Authorised User' of this service. The Homeserver Owner is the organisation represented by the individual who signed up to provision the Service, or the individual themselves if they are not affiliated to any organisation.
 

--- a/docs/identity-server/privacy_notice.md
+++ b/docs/identity-server/privacy_notice.md
@@ -34,9 +34,9 @@ Email: [support@vector.im](mailto:support@vector.im)
 
 Postal address:
 
-10 Queen Street Place<BR>
-London<BR>
-United Kingdom<BR>
+10 Queen Street Place  
+London  
+United Kingdom  
 EC4R 1AG
 
 ##### The Matrix.org Foundation

--- a/docs/identity-server/privacy_notice.md
+++ b/docs/identity-server/privacy_notice.md
@@ -1,6 +1,6 @@
 ---
 title: Vector.im and Matrix.org Identity Servers Privacy Notice
-slug: Privacy Notice 1
+slug: Privacy Notice
 version: 1.0.0
 ---
 

--- a/docs/identity-server/privacy_notice.md
+++ b/docs/identity-server/privacy_notice.md
@@ -1,8 +1,12 @@
-# Vector.im and Matrix.org Identity Servers Privacy Notice
+---
+title: Vector.im and Matrix.org Identity Servers Privacy Notice
+slug: Privacy Notice 1
+version: 1.0.0
+---
 
-# 1. Introduction
+## 1. Introduction
 
-## 1.1 English, Not Legalese
+### 1.1 English, Not Legalese
 
 Data privacy is important, and we want you to understand the issues involved. We have decided to use plain English as much as possible, to make our terms as clear as possible.
 
@@ -14,7 +18,7 @@ Where you read *The Matrix.org Foundation*, or *The Foundation*, it refers to th
 
 Should you have other questions or concerns about this document, please send us an email at [support@matrix.org](mailto:support@matrix.org).
 
-## 1.2 Who Provides this Service?
+### 1.2 Who Provides this Service?
 
 This service is provided by New Vector Ltd. for The Matrix.org Foundation. New Vector Ltd. and The Matrix.org Foundation are Joint Data Controllers for the Service.
 
@@ -22,9 +26,9 @@ This service is provided by New Vector Ltd. for The Matrix.org Foundation. New V
 
 If this agreement is not acceptable, please use an Identity Server provided by someone else (or none at all).
 
-### 1.2.1 Contact Details
+#### 1.2.1 Contact Details
 
-#### New Vector Ltd.
+##### New Vector Ltd.
 
 Email: [support@vector.im](mailto:support@vector.im)
 
@@ -35,17 +39,17 @@ London<BR>
 United Kingdom<BR>
 EC4R 1AG
 
-#### The Matrix.org Foundation
+##### The Matrix.org Foundation
 
 Email: [support@matrix.org](mailto:support@matrix.org)
 
-## 1.3 Using The Service Means Accepting These Terms
+### 1.3 Using The Service Means Accepting These Terms
 
 By accessing or using the Service in any way you agree to and are bound by the terms and conditions written in this document.
 
 If you do not agree to all of the terms and conditions contained in this document, please do not use this service. You can use an Identity Server provided by somebody else, run your own, or not use an Identity Server at all.
 
-## 1.4 This Is a Living Document
+### 1.4 This Is a Living Document
 
 With your help, we want to make our policy documents the best in the industry.
 
@@ -57,49 +61,49 @@ We will likely improve this document over time. By continuing to use the Service
 
 Your access and use of the Service is always subject to the most current version of this document.
 
-# 2. What is a Matrix Identity Server?
+## 2. What is a Matrix Identity Server?
 
 Identity Servers support contact discovery on Matrix by letting people look up [Third Party Identifiers](#threepid) to see if the owner has publicly linked them with their Matrix ID.
 
-# <a name="threepid"></a> 2.1 What is a Third Party Identifier?
+## <a name="threepid"></a> 2.1 What is a Third Party Identifier?
 
 A Third Party Identifier is an identifier that uniquely identifies a person, but _isn't_ a Matrix ID. Most commonly this is an email address or a telephone number.
 
-## 2.2 How does it support contact discovery?
+### 2.2 How does it support contact discovery?
 
 Identity Servers offer the following services:
 
-### Verified Association of Matrix ID with Third Party Identifier
+#### Verified Association of Matrix ID with Third Party Identifier
 
 You can ask the Identity Server to establish that you own your email address or phone number and associate it with your matrix ID. The Identity Server will verify that you own that identifier by sending a link or code to your email address or phone. The association is not considered valid until your ownership of the Third Party Identifier has been confirmed. 
 
-### Account Lookup by Third Party Identifier
+#### Account Lookup by Third Party Identifier
 
 You can look up a Matrix ID by searching for its associated Third Party Identifiers. **You cannot look up Third Party Identifiers by searching for their associated Matrix ID**. For example: if Alice has used the Identity Server to link her email, alice@example.com with her Matrix ID, @example:matrix.org, other users can look up her Matrix ID by querying the Identity Server with her email address, but _they cannot discover her email address by querying the service with her Matrix ID_.
 
 The Identity Server supports both individual and bulk Third Party Identifier lookup:
 
-#### Individual Third Party Identifier Lookup
+##### Individual Third Party Identifier Lookup
 
 Individual Third Party Identifier Lookup is usually used when inviting a user to a Matrix room by their Third Party Identifier.
 
-#### Bulk Third Party Identifier Lookup
+##### Bulk Third Party Identifier Lookup
 
 Bulk Third Party Identifier Lookup is usually used to check whether any of your existing contacts already have a Matrix ID.
 
-#### Registration with Email or Phone Number
+##### Registration with Email or Phone Number
 
 Some homeservers rely upon the Identity Server for part of new user registration, using the Identity Server to perform the verification of ownership of the email address or phone number.
 
 **We will be removing support for user registration from the New Vector Identity Servers.** In the near future homeservers will be able to complete registration by email address without delegating ownership verification to an Identity Server. This document will be updated when this behaviour has changed.
 
-#### Password Reset
+##### Password Reset
 
 Some homeservers rely upon the Identity Server for password reset by email, using the Identity Server to send a unique link to the user to complete password reset securely.
 
 **We will be removing support for password reset from the New Vector Identity Servers.** Homeservers can already complete password reset by email without delegating to an Identity Server. Homeserver administrators should not rely on New Vector Ltd. Identity Servers for password reset.
 
-##### Binding on Registration
+###### Binding on Registration
 
 When your client is configured to use either the vector.im or the matrix.org Identity Server and you register on a homeserver with your email address and/or phone number:
 - if that homeserver is run by New Vector Ltd. (e.g. the homeserver running at matrix.org, or a [Modular](https://modular.im) homeserver), the corresponding homeserver privacy policy will advise you that the act of registration will _also_ publicly link your email address and/or phone number with your Matrix ID via the Identity Server
@@ -107,33 +111,33 @@ When your client is configured to use either the vector.im or the matrix.org Ide
 
 **This behaviour is also being phased out.** In the near future, choosing to publicly link your Third Party Identifiers with your Matrix ID via an Identity Server will be a wholly separate step, fully divorced from registration. This document will be updated when this behaviour has changed.
 
-## 2.3 Closed Federation Between vector.im and matrix.org Identity Servers
+### 2.3 Closed Federation Between vector.im and matrix.org Identity Servers
 
 Data is shared between the vector.im and matrix.org Identity Servers in a closed federation.
 
 This means that when you ask the Identity Server at vector.im to link your Matrix ID with your email address or phone number, this data is replicated on the matrix.org Identity Server. Likewise if you ask the Identity Server at matrix.org to link your Matrix ID with your email address or phone number, this data is replicated onto the vector.im Identity Server.
 
-# 3. Access to Your Data / Privacy Policy
+## 3. Access to Your Data / Privacy Policy
 
-## 3.1 What is the legal basis for processing my data and how does this affect my rights under GDPR (General Data Protection Regulation)?
+### 3.1 What is the legal basis for processing my data and how does this affect my rights under GDPR (General Data Protection Regulation)?
 
-### 3.1.1 Legal Basis for Processing
+#### 3.1.1 Legal Basis for Processing
 
 Your data is processed under *[Legitimate Interest](https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/legitimate-interests/when-can-we-rely-on-legitimate-interests/)*. This means that we process your data only as necessary to deliver the Service, and in a manner that you understand and expect.
 
 The *Legitimate Interest* of the Service is the discoverability of contacts across the wider Matrix ecosystem. The processing of user data we undertake is necessary to provide the Service. **This facility is an optional component of the services provided by New Vector,** designed to make contact discovery easier. Matrix works very well without an Identity Server.
 
-### 3.1.2 Right to Erasure
+#### 3.1.2 Right to Erasure
 
 You can remove your data from the Service at any time by using a Matrix client such as ([https://riot.im/app](https://riot.im/app)) to remove your Third Party Identifiers from the connected Identity Server. The data will be rendered inaccessible across matrix.org and vector.im Identity Servers straight away, and will be deleted from the matrix.org and vector.im databases within 30 days.
 
 If your homeserver is spec-compliant (i.e. if it faithfully implements the Matrix protocol specification detailed at [https://matrix.org/spec](https://matrix.org/spec)), your Third Party Identifiers will be deleted if your account is deactivated.
 
-### 3.1.3 Data Portability
+#### 3.1.3 Data Portability
 
 Under GDPR you have a right to request a copy of your data in a commonly-accepted format. If you would like a copy of your data, please send a request over Matrix to [@gdpr:matrix.org](https://matrix.to/#/@gdpr:matrix.org).
 
-### 3.1.4 Your Rights as Data Subject
+#### 3.1.4 Your Rights as Data Subject
 
 You have rights in relation to the personal data we hold about you. Some of these only apply in certain circumstances. Some of these rights are explored in more detail elsewhere in this document. For completeness, your rights under GDPR are:
 
@@ -155,11 +159,11 @@ You have rights in relation to the personal data we hold about you. Some of thes
 
 For more details about these rights, please see [the guidance provided by the ICO](https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/). If you have any questions or are unsure how to exercise your rights, please contact us at [support@matrix.org](mailto:support@matrix.org).
 
-## 3.2 What Information Do You Collect About Me and Why?
+### 3.2 What Information Do You Collect About Me and Why?
 
 The information we collect is purely for the purpose of letting people discover Matrix IDs that have been publicly linked with a Third Party Identifier (such as email or telephone number). We do **not** profile users or their data on the Service.
 
-### 3.2.1 Information you provide to us:
+#### 3.2.1 Information you provide to us:
 
 We collect information about you when you input it into the Service or otherwise provide it directly to us.
 
@@ -167,23 +171,23 @@ We collect information about you when you input it into the Service or otherwise
 
 * Third Party Identifiers (such as email or telephone number)
 
-### 3.2.2 Information we collect automatically as you use the service:
+#### 3.2.2 Information we collect automatically as you use the service:
 
-#### Third Party Identifiers you look up
+##### Third Party Identifiers you look up
 
 Third Party Identifiers that are looked up are logged in our application logs. These logs are kept for not longer than 180 days. This will change soon - once [https://github.com/matrix-org/sydent/issues/189](https://github.com/matrix-org/sydent/issues/189) lands we will no longer include looked-up Third Party Identifiers in the application logs.
 
-#### Connection Information
+##### Connection Information
 
 Currently, we log the IP address of the party who accesses the Service. Since this is usually the homeserver requesting data on behalf of its user(s), it is usually the IP address of the homeserver that is logged. This data is used in order to mitigate abuse, debug operational issues, and monitor traffic patterns. Our logs are kept for not longer than 180 days.
 
-## 3.3 What Information is Shared With Third Parties and Why?
+### 3.3 What Information is Shared With Third Parties and Why?
 
-### 3.3.1 Sharing Data with Connected Services
+#### 3.3.1 Sharing Data with Connected Services
 
 The purpose of the Service is to share your associated Matrix ID with whomever looks up your linked Third Party Identifiers. As a reminder, use of this service is optional - if you do not want your Matrix ID to be discoverable from your Third Party Identifiers, please do not use the service.
 
-## 3.4 Sharing Data in Compliance with Enforcement Requests and Applicable Laws; Enforcement of Our Rights
+### 3.4 Sharing Data in Compliance with Enforcement Requests and Applicable Laws; Enforcement of Our Rights
 
 In exceptional circumstances, we may share information about you with a third party if we believe that sharing is reasonably necessary to 
 
@@ -195,15 +199,15 @@ In exceptional circumstances, we may share information about you with a third pa
 
 (d) respond to an emergency which we believe in good faith requires us to disclose information to assist in preventing the serious bodily harm of any person.
 
-## 3.5 Our Commitment to Children's Privacy
+### 3.5 Our Commitment to Children's Privacy
 
 We never knowingly collect or maintain information in the Service from those we know are under 16, and no part of the Service is structured to attract anyone under 16. If you are under 16, please do not use the Service.
 
-## 3.6 How Can I Access or Correct My Information?
+### 3.6 How Can I Access or Correct My Information?
 
 You can view and modify your published Third Party Identifiers by using any compatible Matrix client (such as [https://riot.im/app](https://riot.im/app)) and managing your User Settings.
 
-## 3.7 Who Can See My Matrix ID/Third Party Identifier associations?
+### 3.7 Who Can See My Matrix ID/Third Party Identifier associations?
 
 Anyone who knows your Third Party Identifier can query the Service to see if you have publicly linked it with a Matrix ID. Queries _only work in this direction_ It is not possible for parties who only know your Matrix ID to query the service and discover your Third Party Identifiers.
 
@@ -211,13 +215,13 @@ The association between your Matrix ID and your Third Party Identifiers is store
 
 Employees or agents of The Matrix.org Foundation do not have access to the database (except in cases that they are also employees or agents of New Vector Ltd.).
 
-## 3.8 What Are the Guidelines New Vector Follows When Accessing My Data?
+### 3.8 What Are the Guidelines New Vector Follows When Accessing My Data?
 
 * We restrict who at New Vector Ltd. (employees and contractors) can access user data to roles which require access in order to maintain the health of the Service.
 
 * We never share what we see with other users or the general public.
 
-## 3.9 Who Else Has Access to My Data?
+### 3.9 Who Else Has Access to My Data?
 
 We host the majority of the Service in [UpCloud](https://www.upcloud.com/) data centres. Here's [UpCloud's privacy policy](https://www.upcloud.com/blog/updated-terms-privacy-policy-gdpr/). UpCloud controls physical access to their locations.
 
@@ -229,29 +233,30 @@ We use secure private keys when accessing servers via SSH, and protect our AWS c
 
 We log application data (caller IP and user agent). We keep logs for no longer than 180 days.
 
-## 3.10 What happens if New Vector is sold?
+### 3.10 What happens if New Vector is sold?
 
 In the event that we sell or buy any business or assets, we may disclose your personal data to the prospective seller or buyer of such business or assets.
 
 If we or substantially all of our assets are acquired by a third party, personal data held by us about our users will be one of the transferred assets.
 
-## 3.11 How Is My Data Protected from Another User's Data?
+### 3.11 How Is My Data Protected from Another User's Data?
 
 All of our users' data for the Service currently resides in the same database cluster. We use software best practices to guarantee that only people who know your linked Third Party Identifiers can use them to look up your Matrix id. In other words, we segment our user data via software. We do our best and are very confident we're doing a good job at it, but, like every other service that hosts their user data on the same database, we cannot guarantee that it is immune to a sophisticated attack.
 
-## 3.12 What Should I Do If I Find a Security Vulnerability in the Service?
+### 3.12 What Should I Do If I Find a Security Vulnerability in the Service?
 
 If you have discovered a security concern, please follow the Matrix.org [Security Disclosure Policy](https://matrix.org/security-disclosure-policy/).
 
-# 4. Making a Complaint
+## 4. Making a Complaint
 
 We try to meet the highest standards when collecting and using personal information. For this reason, we take any complaints we receive about this very seriously. We encourage people to bring it to our attention at [support@matrix.org](mailto:support@matrix.org) if they think that our collection or use of information is unfair, misleading or inappropriate. We would also welcome any suggestions for improving our procedures.
 
 If you want to make a complaint about the way we have processed your personal information to the supervisory authority, you can contact the ICO (the statutory body which oversees data protection law) at [https://www.ico.org.uk/concerns](https://www.ico.org.uk/concerns).
 
-# 5. Document History
+## 5. Document History
 
-* 2019, July 23: created (content derived from [New Vector Ltd. Matrix.org Homeserver Privacy Policy](https://matrix.org/legal/privacy-notice)).
+| Version | Date | Comment |
+| 1.0.0 | 2019, July 23 | Created (content derived from [New Vector Ltd. Matrix.org Homeserver Privacy Policy](https://matrix.org/legal/privacy-notice)). |
 
 **A note to other startups:** this document was heavily inspired by [Balsamiq's plain English ToS document](https://docs.balsamiq.com/mybalsamiq/tos/). We were impressed by their championing of plain English, and wanted to reproduce that as much as possible in our own legal documentation. Feel free to draw similar inspiration from this document, though be sure to get any documents you produce checked over by a lawyer. Good luck!
 

--- a/docs/matrix-org/code_of_conduct.md
+++ b/docs/matrix-org/code_of_conduct.md
@@ -1,4 +1,8 @@
-# Matrix Code of Conduct
+---
+title: Matrix Code of Conduct
+slug: Matrix Code of Conduct
+version: 1.0.0
+---
 
 This code of conduct outlines our expectations for participants within the Matrix community, as well as steps for reporting unacceptable behaviour. We are committed to providing a welcoming and inspiring community for all, and expect our code of conduct to be honoured. Anyone who violates this code of conduct may be banned from the community.
 

--- a/docs/matrix-org/copyright_notice.md
+++ b/docs/matrix-org/copyright_notice.md
@@ -1,4 +1,8 @@
-# {{ policy_homeserver }} Copyright Notice
+---
+title: {{ policy_homeserver }} Copyright Notice
+slug: Copyright Notice
+version: 1.0.0
+---
 
 Where you read *New Vector*, *New Vector Ltd.* or *we *or* us* below, it refers to the company we created in July 2017 to hire the Matrix core team and support Matrix's development and so run the {{ policy_homeserver }} homeserver: New Vector Ltd., and its French subsidiary: New Vector SARL and their agents.
 

--- a/docs/matrix-org/exceptional_erasure_policy.md
+++ b/docs/matrix-org/exceptional_erasure_policy.md
@@ -1,6 +1,10 @@
-# {{ policy_homeserver }} Policy for Exceptional Exercising of Right To Erasure on State Events
+---
+title: {{ policy_homeserver }} Policy for Exceptional Exercising of Right To Erasure on State Events
+slug: Exceptional Erasure Policy
+version: 1.0.0
+---
 
-# 1. Introduction
+## 1. Introduction
 
 Where you read *New Vector*, *New Vector Ltd.* or *we *or* us* below, it refers to the company we created in July 2017 to hire the Matrix core team and support Matrix's development and so run the {{ policy_homeserver }} homeserver: New Vector Ltd., and its French subsidiary: New Vector SARL and their agents. **This policy does not apply to Matrix servers run by anyone else - Matrix is an open network like the Web and this policy only applies to the server ({{ policy_homeserver }}) provided by New Vector Ltd.**
 
@@ -8,7 +12,7 @@ The legal basis for our processing Personal Data, the reasons for there being re
 
 This document serves to detail how we decide what to do in the event of the interests of an individual user appearing to be in conflict with the broader societal interests.
 
-# 2. How we decide
+## 2. How we decide
 
 As described in the [full {{ policy_homeserver }} Privacy Notice]({{ privacy_policy_uri }}), erasing state events is very damaging to the integrity of a Matrix conversation.
 
@@ -24,7 +28,7 @@ The Personal Data contained in a state event is usually limited to the username,
 
 Each case will be decided based on the factors listed above. In most situations we will not erase state events. In extreme situations, where not erasing state events will place people at material risk of harm, we may choose to erase state events or remove the entire conversation.
 
-# 3. Contacting Us
+## 3. Contacting Us
 
 If you would like us to consider erasing state events containing your Personal Data, please get in touch at [support@matrix.org](mailto:support@matrix.org).
 

--- a/docs/matrix-org/privacy_notice.md
+++ b/docs/matrix-org/privacy_notice.md
@@ -1,10 +1,14 @@
-# {{ policy_homeserver }} Homeserver Privacy Notice
+---
+title: {{ policy_homeserver }} Homeserver Privacy Notice
+slug: Homeserver Privacy Notice
+version: 1.1.0
+---
 
 Please read this document carefully before accessing or using this service!
 
-# 1. Introduction
+## 1. Introduction
 
-## 1.1 English, Not Legalese
+### 1.1 English, Not Legalese
 
 Most Privacy Policy documents are unreadable. They are written by lawyers and for lawyers, and in our opinion are not very effective.
 
@@ -34,7 +38,7 @@ EC4R 1AG
 
 Should you have other questions or concerns about this document, please send us an email at [support@matrix.org](mailto:support@matrix.org).
 
-## 1.2 This Is a Living Document
+### 1.2 This Is a Living Document
 
 This is a living document. With your help, we want to make it the best in the industry.
 
@@ -46,11 +50,11 @@ We will likely improve this document over time and we will take steps to inform 
 
 Your access and use of the Service is always subject to the most current version of this document.
 
-# 2. Access to Your Data / Privacy Policy
+## 2. Access to Your Data / Privacy Policy
 
-## 2.1 What is the legal basis for processing my data and how does this affect my rights under GDPR (General Data Protection Regulation)?
+### 2.1 What is the legal basis for processing my data and how does this affect my rights under GDPR (General Data Protection Regulation)?
 
-### 2.1.1 Legal Basis for Processing
+#### 2.1.1 Legal Basis for Processing
 
 New Vector processes your data under our *[Legitimate Interest](https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/legitimate-interests/when-can-we-rely-on-legitimate-interests/)* to provide our Service to you in a an efficient and secure manner and to ensure the legal compliance and proper administration of our business. Essentially, this means that we process your data only as necessary to deliver the Service and for internal administration purposes, and in a manner that you understand and expect. We also carry out processing that is necessary to provide our Service to you under our Matrix.org Homeserver Terms and Conditions and processing that is necessary to comply with our legal obligations. Where consent is required by law in relation to certain processing, we will ask for your consent.
 
@@ -60,7 +64,7 @@ The nature of the Service and its implementation results in some caveats concern
 
 In situations where the interests of the individual appear to be in conflict with the broader societal interests, we will seek to reconcile those differences guided by our policy.
 
-### 2.1.2 Right to Erasure
+#### 2.1.2 Right to Erasure
 
 You can request that we forget your copy of messages and files by instructing us to deactivate your account (using a matrix client such as [https://riot.im/app](https://riot.im/app)) and selecting the option instructing us to forget your messages. What happens next depends on who else had access to the messages and files you had shared.
 
@@ -70,11 +74,11 @@ Where you shared messages or files with another registered Matrix user, that use
 
 State events are processed differently to non-state events. State events are used by the Service to record, amongst other things, your membership in a room, the configuration of room settings, your changing of another user's power level and your banning a user from a room. Were we to erase these state events from a room entirely, it would be very damaging to other users' experience of the room, causing banned users to become unbanned, revoking legitimate administrator privileges, etc. We therefore share state events sent by your account with all non-essential data removed ('redacted'), even after we have processed your request to be forgotten. This means that your username will continue to be publicly associated with rooms in which you have participated, even after we have processed your request to be forgotten. We are actively [working on a solution to ](https://matrix.org/blog/2018/05/08/gdpr-compliance-in-matrix/#mxid_erasure)[work around](https://matrix.org/blog/2018/05/08/gdpr-compliance-in-matrix/#mxid_erasure)[ this restriction](https://matrix.org/blog/2018/05/08/gdpr-compliance-in-matrix/#mxid_erasure) and allow you to be fully forgotten while maintaining a high quality experience for other users. If this is not acceptable to you, please do not use the Service.
 
-### 2.1.3 Data Portability
+#### 2.1.3 Data Portability
 
 Under GDPR you have a right to request a copy of your data in a commonly-accepted format. If you would like a copy of your data, please send a request over Matrix to [@gdpr:matrix.org](https://matrix.to/#/@gdpr:matrix.org). In the future we will provide a better interface for this!
 
-### 2.1.4 Your Rights as Data Subject
+#### 2.1.4 Your Rights as Data Subject
 
 You have rights in relation to the personal data we hold about you. Some of these only apply in certain circumstances. Some of these rights are explored in more detail elsewhere in this document. For completeness, your rights under GDPR are:
 
@@ -96,17 +100,17 @@ You have rights in relation to the personal data we hold about you. Some of thes
 
 We may ask for proof of identity before responding to your request. For more details about these rights, please see [the guidance provided by the ICO](https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr/individual-rights/). If you have any questions or are unsure how to exercise your rights, please contact us at [support@matrix.org](mailto:support@matrix.org).
 
-## 2.2 What Information Do You Collect About Me and Why?
+### 2.2 What Information Do You Collect About Me and Why?
 
 **The information we collect is purely for the purpose of providing your communication service via Matrix. We do ****not**** profile users or their data on the Service.**
 
 Be aware that while we do not profile users on the Service, third party Matrix clients may gather usage data. Riot.im (the Matrix client provided by New Vector Ltd) optionally gathers opt-in anonymised usage data in order to improve the app. This data is retained for not longer than 13 months.
 
-### 2.2.1 Information you provide to us:
+#### 2.2.1 Information you provide to us:
 
 We collect information about you when you input it into the Service or otherwise provide it directly to us.
 
-#### Account and Profile Information
+##### Account and Profile Information
 
 We collect information about you when you register for an account. This information is kept to a minimum on purpose, and is restricted to:
 
@@ -126,15 +130,15 @@ Your password is stored until you change it or your account is deactivated (see 
 
 Your email address and/or telephone number, if you choose to provide them, are used so that other users can look up your Matrix ID from these identifiers. We will also use your email address to let you reset your password if you forget it, and to send you notifications about missed messages from users trying to contact you on Matrix if you enable the option. We may also send you infrequent urgent messages about platform updates.
 
-#### Content you provide through using the Service
+##### Content you provide through using the Service
 
 We store and distribute the messages and files you share using the Service (and across the wider Matrix ecosystem via federation) as described by the Matrix protocol and according to the access rules configured within the system. **Storing and sharing this content is the reason the Service exists.**
 
 This content includes any information about yourself that you choose to share.
 
-### 2.2.2 Information we collect automatically as you use the Service:
+#### 2.2.2 Information we collect automatically as you use the Service:
 
-#### Device and Connection Information
+##### Device and Connection Information
 
 Each device you use to access the Service is allocated a (user-configurable) identifier. When you access the Service, we record the device identifier, the IP address it used to connect, user agent, and the time at which it last connected to the service.
 
@@ -142,15 +146,15 @@ This information is gathered to help you to manage your devices - you can view a
 
 Currently, we log the IP addresses of everyone who accesses the Service. This data is used in order to mitigate abuse, debug operational issues, and monitor traffic patterns. Our logs are kept for not longer than 180 days. Once Matrix is out of beta we will consider implementing log minimisation.
 
-## 2.3 What Information is Shared With Third Parties and Why?
+### 2.3 What Information is Shared With Third Parties and Why?
 
-### 2.3.1 Sharing Data with Connected Services
+#### 2.3.1 Sharing Data with Connected Services
 
 We may share your information when working with our suppliers and the Matrix Foundation to provide the Service.
 
 In addition, the {{ policy_homeserver }} homeserver is a *decentralised* and *open* service. This means that, to support communication between users on different homeservers or different messaging platforms, your username, display name and messages and files are sometimes shared with other services that are connected with the {{ policy_homeserver }} homeserver.
 
-#### Federation
+##### Federation
 
 Matrix homeservers share user data with the wider ecosystem over federation.
 
@@ -162,7 +166,7 @@ Matrix homeservers share user data with the wider ecosystem over federation.
 
 Access control settings are shared between homeservers, as well as any requests to remove messages by "redactions", or remove personal data under GDPR Article 17 *Right to Erasure (Right to be Forgotten)*. Federated homeservers and Matrix clients which respect the Matrix protocol are expected to honour these controls and redaction/erasure requests, but other federated homeservers are outside of the span of control of New Vector Ltd., and we cannot guarantee how this data will be processed. Federated homeservers can also be located in any territory, and will be subject to the local regulations of that territory. We recommend the use of end-to-end encryption to protect your message and file data over federation, and in future [intend to enable end-to-end encryption by default](https://github.com/vector-im/riot-web/issues/6779).
 
-#### Bridging
+##### Bridging
 
 Some Matrix rooms are bridged to third-party services, such as IRC networks, twitter or email. When a room has been bridged, your username, display name, messages and file transfers may be duplicated on the bridged service where supported.
 
@@ -172,17 +176,17 @@ Some Matrix rooms are bridged to third-party services, such as IRC networks, twi
 
 Access control settings, requests to remove messages by "redactions" or remove personal data under GDPR Article 17 *Right to Erasure (Right to be Forgotten)* are shared to bridging services, which are expected to honour them to the best of their ability. Be aware that not all bridged networks or bridges support the necessary technical capabilities to limit, remove or erase messages. If this is not acceptable to you, please do not use bridged rooms.
 
-#### Integration Services (Bots and Widgets)
+##### Integration Services (Bots and Widgets)
 
 The {{ policy_homeserver }} homeserver provides a range of integrations in the form of Widgets (miniature web applications accessed as part of a Matrix Client) and Bots (automated participants in rooms). Bots and Widgets currently have access to all the messages and files in any room in which they participate, although we are adding a more sophisticated access control system.
 
-### Transfers of your Data
+#### Transfers of your Data
 
 If you use our Service your data will be transferred outside of the EU to other homeservers and services connected with matrix.org as this is necessary to provide the Service to you. By the very nature of our Service, such transfers will occur regularly and we have no control over the safeguards adopted by third party recipients.
 
 Where we engage suppliers to process your data outside the EU we will ensure that appropriate safeguards such as the standard contractual clauses are in place.
 
-## 2.4 Sharing Data in Compliance with Enforcement Requests and Applicable Laws; Enforcement of Our Rights
+### 2.4 Sharing Data in Compliance with Enforcement Requests and Applicable Laws; Enforcement of Our Rights
 
 In exceptional circumstances, we may share information about you with a third party if we believe that sharing is reasonably necessary to 
 
@@ -194,7 +198,7 @@ In exceptional circumstances, we may share information about you with a third pa
 
 (d) respond to an emergency which we believe in good faith requires us to disclose information to assist in preventing the serious bodily harm of any person.
 
-## 2.5 How Do You Handle Passwords?
+### 2.5 How Do You Handle Passwords?
 
 We never store password data in plain text; instead they are stored hashed (with at least 4096 rounds of bcrypt, including both a salt and a server-side pepper secret). Passwords sent to the server are encrypted using SSL.
 
@@ -208,15 +212,15 @@ You can manage your account by using a Matrix client such as [https://riot.im/ap
 
 We will never change a password for you.
 
-## 2.6 Our Commitment to Children's Privacy
+### 2.6 Our Commitment to Children's Privacy
 
 We never knowingly collect or maintain information in the Service from those we know are under 16, and no part of the Service is structured to attract anyone under 16. If you are under 16, please do not use the Service.
 
-## 2.7 How Can I Access or Correct My Information?
+### 2.7 How Can I Access or Correct My Information?
 
 You can access all your personally identifiable information that we collect by using any compatible Matrix client (such as [https://riot.im/app](https://riot.im/app)) and managing your User Settings. You can download a copy of all your data as per section 2.1.3.
 
-## 2.8 Who Can See My Messages and Files?
+### 2.8 Who Can See My Messages and Files?
 
 In unencrypted and encrypted rooms, users connecting to the {{ policy_homeserver }} homeserver (directly or over federation) will be able to see messages and files according to the access permissions configuration of the relevant room. This data is stored in the format it was received on our servers, and can be viewed by New Vector engineers (employees and contractors) under the conditions outlined below.
 
@@ -224,13 +228,13 @@ In encrypted rooms, the data is stored in our databases but the encryption keys 
 
 We use HTTPS to transfer all data. End-to-end encrypted messaging data is stored encrypted using AES-256, using message keys generated using the [Olm and Megolm cryptographic ratchets](https://matrix.org/blog/2016/11/21/matrixs-olm-end-to-end-encryption-security-assessment-released-and-implemented-cross-platform-on-riot-at-last/).
 
-## 2.9 What Are the Guidelines New Vector Follows When Accessing My Data?
+### 2.9 What Are the Guidelines New Vector Follows When Accessing My Data?
 
 * We restrict who at New Vector Ltd. (employees and contractors) can access user data to roles which require access in order to maintain the health of the Service.
 
 * We never share what we see with other users or the general public.
 
-## 2.10 Who Else Has Access to My Data?
+### 2.10 Who Else Has Access to My Data?
 
 We host the majority of the Service in [UpCloud](https://www.upcloud.com/) data centres. Here's [UpCloud's privacy policy](https://www.upcloud.com/blog/updated-terms-privacy-policy-gdpr/). UpCloud controls physical access to their locations.
 
@@ -244,33 +248,33 @@ We use secure private keys when accessing servers via SSH, and protect our AWS c
 
 We log application data (username, user IP and user agent). We keep logs for no longer than 180 days.
 
-## 2.11 What happens if New Vector is sold?
+### 2.11 What happens if New Vector is sold?
 
 In the event that we sell or buy any business or assets, we may disclose your personal data to the prospective seller or buyer of such business or assets.
 
 If we or substantially all of our assets are acquired by a third party, personal data held by us about our users will be one of the transferred assets.
 
-## 2.12 How Is My Data Protected from Another User's Data?
+### 2.12 How Is My Data Protected from Another User's Data?
 
 All of our users' data for the Service currently resides in the same database cluster which is due to the nature of our Service. We use software best practices to guarantee that only people who you designate as viewers of your data can access it. In other words, we segment our user data via software. We do our best and are very confident we're doing a good job at it, but, like every other service that hosts their user data on the same database, we cannot guarantee that it is immune to a sophisticated attack.
 
-## 2.13 What Should I Do If I Find a Security Vulnerability in the Service?
+### 2.13 What Should I Do If I Find a Security Vulnerability in the Service?
 
 If you have discovered a security concern, please email us at [security@matrix.org](mailto:security@matrix.org). We'll work with you to make sure that we understand the scope of the issue, and that we fully address your concern. We consider correspondence sent to [security@matrix.org](mailto:security@matrix.org) our highest priority, and work to address any issues that arise as quickly as possible.
 
 Please act in good faith towards our users' privacy and data during your disclosure. White hat security researchers are always appreciated.
 
-# 3. Making a Complaint
+## 3. Making a Complaint
 
 We try to meet the highest standards when collecting and using personal information. For this reason, we take any complaints we receive about this very seriously. We encourage people to bring it to our attention at [support@matrix.org](mailto:support@matrix.org) if they think that our collection or use of information is unfair, misleading or inappropriate. We would also welcome any suggestions for improving our procedures.
 
 If you want to make a complaint about the way we have processed your personal information to the supervisory authority, you can contact the ICO (the statutory body which oversees data protection law) at [https://www.ico.org.uk/concerns](https://www.ico.org.uk/concerns).
 
-# 4. Document History
+## 4. Document History
 
-* 2018, March 28: created.
+* 2018, March 28: created (1.0.0)
 
-* 2019, August 22: revised.
+* 2019, August 22: revised (1.1.0)
 
 **A note to other startups:** this document was heavily inspired by [Balsamiq's plain English ToS document](https://docs.balsamiq.com/mybalsamiq/tos/). We were impressed by their championing of plain English, and wanted to reproduce that as much as possible in our own legal documentation. Feel free to draw similar inspiration from this document, though be sure to get any documents you produce checked over by a lawyer. Good luck!
 

--- a/docs/matrix-org/terms_and_conditions.md
+++ b/docs/matrix-org/terms_and_conditions.md
@@ -1,10 +1,14 @@
-# {{ policy_homeserver }} Homeserver Terms and Conditions
+---
+title: {{ policy_homeserver }} Homeserver Terms and Conditions
+slug: Homeserver Terms and Conditions
+version: 1.0.0
+---
 
 Please read this document carefully before accessing or using this service!
 
-# 1. Introduction
+## 1. Introduction
 
-## 1.1 English, Not Legalese
+### 1.1 English, Not Legalese
 
 Most Terms of Use and Privacy Policy documents are unreadable. They are written by lawyers and for lawyers, and in our opinion are not very effective.
 
@@ -32,13 +36,13 @@ EC4R 1AG
 
 Should you have other questions or concerns about this document, please send us an email at [support@matrix.org](mailto:support@matrix.org).
 
-## 1.2 Using The Service Means Accepting These Terms
+### 1.2 Using The Service Means Accepting These Terms
 
 By accessing or using the Service in any way, whether you have created a Matrix account on the {{ policy_homeserver }} homeserver, or whether you are accessing content federated from the {{ policy_homeserver }} homeserver to another Matrix homeserver, or are just browsing rooms as an unauthenticated guest, you agree to and are bound by the terms and conditions written in this document.
 
 If you do not agree to all of the terms and conditions contained in this document, please use a Matrix server provided by someone else and refrain from accessing content federated from this server.
 
-## 1.3 This Is a Living Document
+### 1.3 This Is a Living Document
 
 This is a living document. With your help, we want to make it the best in the industry.
 
@@ -50,7 +54,7 @@ We will likely improve this document over time. By continuing to use the Service
 
 Your access and use of the Service is always subject to the most current version of this document.
 
-## 1.4 Breach of Terms
+### 1.4 Breach of Terms
 
 If you breach any of the terms and conditions in this document, your authorization to access or use the Service automatically terminates. 
 
@@ -58,7 +62,7 @@ We may block, restrict, disable, suspend or terminate your access to all or part
 
 If you think we removed your access by mistake, send an email to [support@matrix.org](mailto:support@matrix.org) and we'll give you our reasoning.
 
-# 2. Support
+## 2. Support
 
 Support for the {{ policy_homeserver }} homeserver is provided on a best effort basis by New Vector Ltd - however, support is often available from the wider Matrix Community in the public Matrix Support rooms (as listed in the [+matrix:matrix.org](https://matrix.to/#/+matrix:matrix.org) community).
 
@@ -66,11 +70,11 @@ Queries sent to [support@matrix.org](mailto:support@matrix.org) will be addresse
 
 We love Matrix and will support our users as much as we can, but we are also a small team and value our work/life balance. This means that although we'll try our best, we do not provide 24/7 support.
 
-# 3. Intellectual Property Rights
+## 3. Intellectual Property Rights
 
 *Note on Plain English: We know that the language in this section still reads like legalese - this will be improved in later revisions of this document.*
 
-## 3.1 Who Owns the IP of My Messages and Files?
+### 3.1 Who Owns the IP of My Messages and Files?
 
 We do not claim intellectual property rights over rooms, message content or files uploaded to the Service.
 
@@ -82,9 +86,9 @@ You are solely and entirely responsible for all of your messages and files that 
 
 You acknowledge and agree that by accessing or using the Service, you may be exposed to user materials from others that are offensive, indecent or otherwise objectionable.
 
-# 4. Reliability
+## 4. Reliability
 
-## 4.1 Do You Guarantee That The Service Will Be Accessible at All Times?
+### 4.1 Do You Guarantee That The Service Will Be Accessible at All Times?
 
 In short, we do not. Like all other cloud-based applications, we are vulnerable to the inherent unreliability of the Internet. We do not offer contracted SLA for availability of the Service and your data.
 
@@ -92,7 +96,7 @@ We monitor the Service closely and have set up automated alarms to be notified (
 
 You acknowledge and agree that New Vector Ltd. shall not be liable for any failure to store your materials on the {{ policy_homeserver }} homeserver at any time.
 
-# 5. App Developers
+## 5. App Developers
 
 We encourage you to write software that uses the Matrix Protocol and interfaces with the Service! 
 
@@ -100,11 +104,11 @@ The Matrix Protocol and our implementation will change over time, and we may cha
 
 Provided that you comply with the terms of this Agreement and our policies and procedures, you may use the Service to execute Applications owned by you. You are solely responsible for your Applications, including any data, text, images or content they contain.
 
-# 6. Play Nice Clauses
+## 6. Play Nice Clauses
 
 *Note on Plain English: We know that the language in this section still reads like legalese - this will be improved in later revisions of this document.*
 
-## 6.1 Use of The Service
+### 6.1 Use of The Service
 
 You agree that you shall not:
 
@@ -134,23 +138,23 @@ You agree that you shall not:
 
 Materials and Services provided by third parties are governed by separate agreements accompanying such materials and services. New Vector Ltd. offers no guarantees and assumes no responsibility or liability of any type with respect to the third-party services, including any liability resulting from incompatibility between a third-party service, the {{ policy_homeserver }} service or another third-party service. You agree that you will not hold New Vector Ltd. responsible or liable with respect to the third-party services.
 
-## 6.2 Illegal Content
+### 6.2 Illegal Content
 
 Any content containing or promoting indecent images/depictions of children is illegal and utterly prohibited on the Service. When we become aware of such content, we refer the details to the relevant authorities. If you've found an account, room or group being used for the distribution or promotion of child sexual exploitation, please share the details in an email to [abuse@matrix.org](mailto:abuse@matrix.org).
 
-# 7. Restriction and Termination of Use
+## 7. Restriction and Termination of Use
 
 We may block, restrict, disable, suspend or terminate your access to all or part of the Service at any time in our sole discretion, without prior notice or liability to you.
 
-# 8. Encryption
+## 8. Encryption
 
 The Services may allow you to encrypt your communications end-to-end between devices. There may be restrictions and limitations on the import, possession, use, transfer and/or export of strong encryption technology under the laws of the country in which you intend to use the Service. It is your sole obligation and responsibility to check such restrictions and limitations before using the Service and to comply with them. We reserve the right to suspend the Service immediately and without notice if we determine, in our sole judgment, that the Service is being used in violation of local regulations governing the use of cryptographic technologies (even though we have no responsibility to make such determination).
 
-# 9. Links to Third Party Sites
+## 9. Links to Third Party Sites
 
 The Service may include links that will take you to other sites outside of the the Service. The linked sites are provided as a convenience and the inclusion of the links do not imply any endorsement by us of any linked site. We have no control of the linked sites and you therefore acknowledge and agree that we are not responsible for the contents of any linked site, any link contained in a linked site or any changes or updates to a linked site. You further acknowledge and agree that we are not responsible for any form of transmission (e.g. webcasting) received from any linked site.
 
-# 10. Warranties and Disclaimers
+## 10. Warranties and Disclaimers
 
 The {{ policy_homeserver }} service is provided by New Vector under these terms of use "as is" without warranty of any kind, either express, implied, statutory or otherwise, including, but not limited to, the implied warranties of title, non-infringement, merchantability or fitness for a particular purpose. Without limiting the foregoing, New Vector makes no warranty that:
 
@@ -178,7 +182,7 @@ The use of the Service is done at your own discretion and risk and with your agr
 
 Some states or jurisdictions do not allow the exclusion of implied warranties or limitations on how long an implied warranty may last, so the above limitations may not apply to you. To the extent permissible, any implied warranties are limited to ninety days.
 
-# 11. Indemnity and Liability
+## 11. Indemnity and Liability
 
 *Note on Plain English: We know that the language in this section still reads like legalese - this will be improved in later revisions of this document.*
 
@@ -200,11 +204,11 @@ You agree to indemnify and hold New Vector and its officers, co-branders, other 
 
 8. any dealings between you and any third parties advertising or promoting via the Service.
 
-# 12. Emergency Service Calls
+## 12. Emergency Service Calls
 
 The Service does not and is not intended to support or carry emergency calls to any emergency services (e.g. E911 or 112 numbers). We are not liable for any claims, damages or loss which arise from this limitation.
 
-# 13. Limitation of Liability
+## 13. Limitation of Liability
 
 *Note on Plain English: We know that the language in this section still reads like legalese - this will be improved in later revisions of this document.*
 
@@ -230,21 +234,21 @@ In no event shall New Vector, its officers, directors, employees, partners or su
 
 Some jurisdictions prohibit the exclusion or limitation of liability for consequential or incidental damages. Accordingly, the limitations and exclusions set forth above may not apply to you.
 
-# 14. Governing Law and Jurisdiction
+## 14. Governing Law and Jurisdiction
 
 This Agreement shall be governed by the laws of England and Wales, excluding its conflict of law provisions. Unless contrary to the law where you reside, all disputes relating to this Agreement are subject to the exclusive jurisdiction of the courts of England and Wales and you expressly consent to the exercise of personal jurisdiction in the courts of England and Wales in connection with any such dispute. This Agreement shall not be governed by the United Nations Convention on Contracts for the International Sale of Goods.
 
-# 15. General
+## 15. General
 
 The Service is licensed, not sold, to you by New Vector Ltd for use strictly in accordance with the terms and conditions of this Agreement. Ownership of the Service shall at all times remain with New Vector Ltd. Access to the Service is provided to you only to allow you to exercise your rights under this Agreement.
 
-## 15.1 Grant of Licence
+### 15.1 Grant of Licence
 
 Subject to your acceptance of, and compliance with, this Agreement and any payment requirements for the Service (if applicable), New Vector Ltd hereby grants you a limited, non-exclusive, non-transferable, revocable, non-sublicensable licence, in and under our intellectual property rights, to access and use the Services, solely in accordance with the terms and conditions of this Agreement. Unless explicitly stated otherwise, any new features provided by us that augment or enhance the current Service shall also constitute "Service" and shall be subject to these terms and conditions. All rights not expressly granted under this Agreement are retained by New Vector Ltd.
 
 You may also be subject to additional terms and conditions that may apply when you use other New Vector services, third party content or third party software. If for any reason a court of competent jurisdiction finds any provision of the Terms of Use, or portion thereof, to be unenforceable, that provision shall be enforced to the maximum extent permissible so as to effect the intent of the parties as reflected by that provision, and the remainder of the Terms of Use shall continue in full force and effect. Any failure by New Vector to enforce or exercise any provision of the Terms of Use or related right shall not constitute a waiver of that right or provision. The section titles used in the Terms of Use are purely for convenience and carry with them no legal or contractual effect.
 
-# 16. Document History
+## 16. Document History
 
 * 2018, March 28: created.
 

--- a/docs/modular-im/cookie_policy.md
+++ b/docs/modular-im/cookie_policy.md
@@ -1,16 +1,20 @@
-# Modular.im Cookie Policy
+---
+title: Modular.im Cookie Policy
+slug: Modular.im Cookie Policy
+version: 1.0.0
+---
 
 This is the Cookie Policy for https://www.modular.im.
 
-# Our use of cookies and similar technologies
+## Our use of cookies and similar technologies
 
 We use cookies to support key application functionality and to improve your experience of the application.
 
-## What are cookies and why do we use them?
+### What are cookies and why do we use them?
 
 Cookies are small files that websites place on your computer as you browse the web.
 
-### Cookies for analytics
+#### Cookies for analytics
 
 We use cookies to help us track anonymous usage data - this data helps us understand how our users are using the application so that we can make improvements.
 
@@ -20,12 +24,12 @@ Our analytics are powered by the Free and Open Source analytics platform [Matomo
 
 All cookies created by Matomo start with either  _pk_ref, _pk_cvar, _pk_id, or _pk_ses.
 
-### Cookies for security
+#### Cookies for security
 
 We use Cloudflare to mitigate the risk of DDoS attacks. Cloudflare uses the __cfduid cookie to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
 
 This cookie is required to support core functionality and so cannot be disabled.
 
-### Cookies for payment
+#### Cookies for payment
 
 We use Stripe to process payments. Stripe uses a number of cookies to support its payment processing.

--- a/docs/modular-im/privacy_notice.md
+++ b/docs/modular-im/privacy_notice.md
@@ -1,4 +1,8 @@
-# Modular.im Customer Privacy Notice
+---
+title: Modular.im Customer Privacy Notice
+slug: Privacy Notice
+version: 1.0.0
+---
 
 Please read this document carefully before accessing or using this service!
 
@@ -20,10 +24,10 @@ New Vector Ltd. is both the Data Controller and the Data Processor for Modular. 
 
 Email: [support@matrix.org](mailto:support@matrix.org)
 
-Postal address:
-10 Queen Street Place
-London
-United Kingdom
+Postal address:  
+10 Queen Street Place  
+London  
+United Kingdom  
 EC4R 1AG
 
 Should you have other questions or concerns about this document, please send us an email at [support@matrix.org](mailto:support@matrix.org).

--- a/docs/modular-im/terms_and_conditions.md
+++ b/docs/modular-im/terms_and_conditions.md
@@ -1,4 +1,8 @@
-# Hosted Homeserver Customer Terms and Conditions
+---
+title: Hosted Homeserver Customer Terms and Conditions
+slug: Privacy Notice
+version: 1.0.0
+---
 
 These Hosted Homeserver Customer Terms and Conditions ('Customer Terms') govern your use and access of our Services.  Authorised Users are bound by the Users Terms and Conditions ('Users Terms'). Please read this document carefully before accessing or using this service!
 

--- a/docs/riot-im/cookie_policy.md
+++ b/docs/riot-im/cookie_policy.md
@@ -1,16 +1,20 @@
-# Riot.im Cookie Policy
+---
+title: Riot.im Cookie Policy
+slug: Privacy Notice
+version: 1.0.0
+---
 
 This is the Cookie Policy for the Matrix client Riot.im when accessed from [{{ riot_link_text }}]({{ riot_link_uri }}), as run by by New Vector Ltd. It does not apply to other deployments of Riot.im.
 
-# Our use of cookies and similar technologies
+## Our use of cookies and similar technologies
 
 We use cookies and similar technologies, such as local storage and IndexedDB, to support key application functionality and to improve your experience of the application.
 
-## What are cookies and why do we use them?
+### What are cookies and why do we use them?
 
 Cookies are small files that websites place on your computer as you browse the web.
 
-### Cookies for analytics
+#### Cookies for analytics
 
 We use cookies to help us track anonymous usage data - this data helps us understand how our users are using the application so that we can make improvements.
 
@@ -20,13 +24,13 @@ Our analytics are powered by the Free and Open Source analytics platform [Matomo
 
 All cookies created by Matomo start with either  _pk_ref, _pk_cvar, _pk_id, or _pk_ses.
 
-### Cookies for security
+#### Cookies for security
 
 We use Cloudflare to mitigate the risk of DDoS attacks. Cloudflare uses the __cfduid cookie to identify individual clients behind a shared IP address and apply security settings on a per-client basis.
 
 This cookie is required to support core functionality and so cannot be disabled.
 
-## What are local storage and IndexedDB and why do we use them?
+### What are local storage and IndexedDB and why do we use them?
 
 Local storage and IndexedDB are facilities provided by most modern browsers to support storage of application data locally.
 

--- a/docs/riot-im/privacy_notice.md
+++ b/docs/riot-im/privacy_notice.md
@@ -1,8 +1,12 @@
-Riot.im Privacy Notice
+---
+title: Riot.im Privacy Notice
+slug: Riot.im Privacy Notice
+version: 1.0.0
+---
 
 Please read this document carefully before accessing or using this service!
 
-# 1. Introduction
+## 1. Introduction
 
 Riot.im is an Open Source Matrix client which you can use to connect to any server that implements the Matrix protocol.
 
@@ -10,7 +14,7 @@ Where you read *New Vector*, *New Vector Ltd.* or *we *or* us* below, it refers 
 
 Where you read 'the Service' in this document, it refers to the Riot.im instances exposed on [riot.im](https://riot.im) (or subdomains) by New Vector Ltd.
 
-## 1.1 Riot.im Instances Provided By New Vector
+### 1.1 Riot.im Instances Provided By New Vector
 
 *New Vector Ltd* hosts several Riot.im instances at [https://riot.im/](https://riot.im/). Today these include:
 
@@ -24,13 +28,13 @@ This agreement covers all of these instances, and any others that we may choose 
 
 **This agreement does not cover Riot.im instances hosted by anyone else.**
 
-## 1.2 Company Contact Information
+### 1.2 Company Contact Information
 
 Email: [support@vector.org](mailto:support@vector.org)
 
 Postal address: 10 Queen Street Place, London, United Kingdom. EC4R 1AG.
 
-# 2. Your Data Privacy and the Matrix Server
+## 2. Your Data Privacy and the Matrix Server
 
 In giving you access to the Service we collect the bare minimum of information required to expose any service via the web.
 
@@ -46,9 +50,9 @@ If you are using the server provided by New Vector Ltd, **matrix.org**, you can 
 
 * Matrix.org Copyright Notice - [https://matrix.org/docs/guides/copyright_notice](https://matrix.org/docs/guides/copyright_notice)
 
-# 3. What Data We Collect
+## 3. What Data We Collect
 
-## Data collected automatically
+### Data collected automatically
 
 We collect your IP address when you request access to the Riot.im client from our web server. This data is collected under legitimate interest, as per GDPR Recital 49.
 
@@ -56,7 +60,7 @@ We use Cloudflare to protect against DDoS attacks, so both New Vector Ltd and Cl
 
 We collect this information to support operational maintenance and to protect against malicious actions against our infrastructure. This data is deleted automatically after 180 days.
 
-## Data collected if you opt-in to analytics
+### Data collected if you opt-in to analytics
 
 All our analytics data is **opt-in** and **fully anonymised**. We don't record any personal or identifiable data for our analytics.
 

--- a/docs/shop-matrix-org/privacy_notice.md
+++ b/docs/shop-matrix-org/privacy_notice.md
@@ -1,7 +1,8 @@
 ---
-section: legal
-version: v1.0
 title: Matrix.org Shop Privacy Notice
+slug: Matrix.org Shop Privacy Notice
+version: 1.0.0
+section: legal
 ---
 
 ## 1. Introduction


### PR DESCRIPTION
Metadata added to all of the policy docs; apart from the matrix.org homeserver privacy notice I've declared them all 1.0.0 and we can track versions from here.